### PR TITLE
Fix `intranode_allgather` benchmarks

### DIFF
--- a/scripts/run_bench_intranode_allgather.sh
+++ b/scripts/run_bench_intranode_allgather.sh
@@ -8,6 +8,9 @@ fi
 
 NPROC_PER_NODE=$1
 
+# export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+export TORCH_NCCL_BLOCKING_WAIT=1
+
 torchrun \
     --nproc_per_node=$NPROC_PER_NODE \
     benchmarks/bench_allgather.py


### PR DESCRIPTION
Fixes #23 

As mentioned in issue #23, the bus bandwidth drops when data size(per rank) is greater than 256MB, which is abnormal since `nccl_tests` has shown that larger data size is expected to yield better performance. After studying and experimenting, disabling torch watchdog by setting `TORCH_NCCL_BLOCKING_WAIT=1` works well on my H20 machine. Simply put, torch watchdog is a thread to handle NCCL errors and will preempt the thread which is about to launch NCCL operators. So torch watchdog leads to a launch skew among all the ranks by postponing the kernel launch of one or several of all ranks.

However, I still cannot explain why are there so many `cudaFree` postponing kernel launch shown by `Nsight System`. The mechanism under the hood is still a maze to me. To continue features development, I suppose it is appropriate to temporarily fix this bug in benchmark, and perhaps later I or anyone else provide a document to illustrate this bug.