### PR TITLE
feat: Support ring intranode `all-gather`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,21 @@ All benchmarks were conducted on NVIDIA H20 GPUs with NVLink connectivity:
 
 | Type      | Data Size | NCCL (GB/s)     | Hybrid (GB/s)   |
 | --------- |-----------|-----------------|-----------------|
-| Intranode | 4 KB      | 0.18            |    0.54         |
-| Intranode | 16 KB     | 1.00            |    2.12         |
-| Intranode | 64 KB     | 3.63            |    8.10         |
-| Intranode | 256 KB    | 11.13           |    29.30        |
-| Intranode | 1024 KB   | 53.61           |    73.43        |
-| Intranode | 2 MB      | 76.51           |    87.27        |
-| Intranode | 4 MB      | 107.46          |    92.57        |
-| Intranode | 8 MB      | 170.90          |    99.19        |
-| Intranode | 16 MB     | 210.44          |    93.75        |
-| Intranode | 32 MB     | 230.63          |    92.16        |
-| Intranode | 64 MB     | 239.52          |    93.24        |
+| Intranode | 4 KB      | 1.02            |    0.18         |
+| Intranode | 16 KB     | 2.48            |    0.74         |
+| Intranode | 64 KB     | 13.87           |    2.96         |
+| Intranode | 256 KB    | 57.33           |    11.71        |
+| Intranode | 1024 KB   | 126.60          |    41.55        |
+| Intranode | 2 MB      | 198.55          |    73.40        |
+| Intranode | 4 MB      | 234.00          |    118.41       |
+| Intranode | 8 MB      | 280.46          |    172.19       |
+| Intranode | 16 MB     | 308.44          |    188.47       |
+| Intranode | 32 MB     | 328.32          |    204.16       |
+| Intranode | 64 MB     | 336.90          |    216.75       |
+| Intranode | 128 MB    | 345.00          |    225.75       |
+| Intranode | 256 MB    | 352.18          |    230.39       |
+| Intranode | 512 MB    | 356.45          |    232.82       |
+| Intranode | 1024 MB   | 359.75          |    231.51       |
 | Internode | 4 KB      | 0.29            |    0.16         |
 | Internode | 16 kB     | 0.92            |    0.62         |
 | Internode | 64 KB     | 5.40            |    2.39         |

--- a/csrc/buffer.cuh
+++ b/csrc/buffer.cuh
@@ -118,12 +118,6 @@ class Buffer {
 
   // Use prime number as start and stride to avoid
   // collision among different calls.
-  const uint32_t PRIME_TAG_START{13};
-
-  // TODO(Gin): Support adaptive stride to ensure
-  // stride is greater than num_nvl_ranks_.
-  const uint32_t PRIME_TAG_STRIDE{971};
-
   uint32_t tag{PRIME_TAG_START};
 };
 }  // namespace nvshmem_tutorial

--- a/csrc/buffer.cuh
+++ b/csrc/buffer.cuh
@@ -42,7 +42,7 @@ class Buffer {
   // Receives a tensor synchronously.
   void intranode_recv(torch::Tensor& tensor, int rank);
   // Gathers tensors from the whole group in a list.
-  void intranode_all_gather(std::vector<torch::Tensor>& tensor_list,
+  void intranode_all_gather(torch::Tensor& output_tensor,
                             const torch::Tensor& tensor, bool async_op);
 
   void intranode_all_to_all(torch::Tensor input, torch::Tensor output,

--- a/csrc/buffer.cuh
+++ b/csrc/buffer.cuh
@@ -116,5 +116,15 @@ class Buffer {
   std::vector<at::cuda::CUDAStream> comm_streams_;
 
   bool destroyed_{false};
+
+  // Use prime number as start and stride to avoid
+  // collision among different calls.
+  const uint32_t PRIME_TAG_START{13};
+
+  // TODO(Gin): Support adaptive stride to ensure
+  // stride is greater than num_nvl_ranks_.
+  const uint32_t PRIME_TAG_STRIDE{971};
+
+  uint32_t tag{PRIME_TAG_START};
 };
 }  // namespace nvshmem_tutorial

--- a/csrc/intranode.cu
+++ b/csrc/intranode.cu
@@ -46,57 +46,86 @@ void Buffer::intranode_all_gather(torch::Tensor& output_tensor,
     throw std::runtime_error("Local NVLink buffer not allocated");
   }
 
-  int prev_rank = (nvl_rank_ - 1 + num_nvl_ranks_) % num_nvl_ranks_;
-  int next_rank = (nvl_rank_ + 1) % num_nvl_ranks_;
-  int64_t num_bytes = tensor.nbytes();
-  int64_t output_size = output_tensor.nbytes();
+  // Double buffer
+  uint64_t ping = 0, pong = 1, offset = 0, num_bytes = tensor.nbytes();
+  uint32_t prev_rank = (nvl_rank_ - 1 + num_nvl_ranks_) % num_nvl_ranks_;
+  uint32_t next_rank = (nvl_rank_ + 1) % num_nvl_ranks_;
+  const uint64_t num_flags = 4;   // Use 4 flags: sig, ack, local_copy_start, local_copy_end
   char *output_ptr = static_cast<char*>(output_tensor.data_ptr());
-  auto curr_sig_flag_ptr = reinterpret_cast<CUdeviceptr>(static_cast<char*>(buffer_ptrs_[nvl_rank_]) + output_size);
-  auto next_sig_flag_ptr = reinterpret_cast<CUdeviceptr>(static_cast<char*>(buffer_ptrs_[next_rank]) + output_size);
-  auto curr_ack_flag_ptr = reinterpret_cast<CUdeviceptr>(static_cast<char*>(buffer_ptrs_[nvl_rank_]) + output_size + sizeof(int));
-  auto prev_ack_flag_ptr = reinterpret_cast<CUdeviceptr>(static_cast<char*>(buffer_ptrs_[prev_rank]) + output_size + sizeof(int));
-  void *init_dst_slot_ptr = static_cast<char*>(buffer_ptrs_[next_rank]) + nvl_rank_ * num_bytes;
+  char *curr_base_ptr = static_cast<char*>(buffer_ptrs_[nvl_rank_]);
+  char *next_base_ptr = static_cast<char*>(buffer_ptrs_[next_rank]);
+  char *prev_base_ptr = static_cast<char*>(buffer_ptrs_[prev_rank]);
+  char *curr_data_base_ptr = curr_base_ptr + num_flags * sizeof(int);
+  char *next_data_base_ptr = next_base_ptr + num_flags * sizeof(int);
+  auto curr_sig_flag_ptr = reinterpret_cast<CUdeviceptr>(curr_base_ptr);
+  auto next_sig_flag_ptr = reinterpret_cast<CUdeviceptr>(next_base_ptr);
+  auto curr_ack_flag_ptr = reinterpret_cast<CUdeviceptr>(curr_base_ptr + sizeof(int));
+  auto prev_ack_flag_ptr = reinterpret_cast<CUdeviceptr>(prev_base_ptr + sizeof(int));
+  auto local_copy_start_ptr = reinterpret_cast<CUdeviceptr>(curr_base_ptr + 2 * sizeof(int));
+  auto local_copy_end_ptr = reinterpret_cast<CUdeviceptr>(curr_base_ptr + 3 * sizeof(int));
+  void *output_dst_slot_ptr = output_ptr + nvl_rank_ * num_bytes;
+  void *nvl_src_slot_ptr = NULL, *nvl_dst_slot_ptr = NULL;
 
-  // Copy input into output slot.
-  void *output_dst_slot_ptr = static_cast<char*>(output_ptr) + nvl_rank_ * num_bytes;
-  CUDA_CHECK(cudaMemcpyAsync(output_dst_slot_ptr, tensor.data_ptr(),
-                             num_bytes, cudaMemcpyDeviceToDevice,
-                             comm_streams_[prev_rank]));
-
-  // Send input to next rank.
-  CUDA_CHECK(cudaMemcpyAsync(init_dst_slot_ptr, tensor.data_ptr(), 
+  // Send input to NVLink buffer.
+  nvl_src_slot_ptr = curr_data_base_ptr + ping * num_bytes;
+  CUDA_CHECK(cudaMemcpyAsync(nvl_src_slot_ptr, tensor.data_ptr(), 
                              num_bytes, cudaMemcpyDeviceToDevice, 
                              comm_streams_[nvl_rank_]));
 
-  // Run the ring for world_size - 1 steps.
-  for (int step = 1; step < num_nvl_ranks_; ++step) {
-    // Write sig to next rank.
-    cuStreamWriteValue32(comm_streams_[nvl_rank_], next_sig_flag_ptr, step - 1, 0);
+  // Run the ring for (world_size - 1) steps.
+  for (uint32_t step = 0; step < num_nvl_ranks_ - 1; ++step) {
+    // Write ack to prev_rank to ack the last step data.
+    cuStreamWriteValue32(comm_streams_[nvl_rank_], prev_ack_flag_ptr, tag + step - 1, 0);
 
-    // Wait signal from prev rank.
-    cuStreamWaitValue32(comm_streams_[nvl_rank_], curr_sig_flag_ptr, step - 1, 0);
-    cuStreamWaitValue32(comm_streams_[prev_rank], curr_sig_flag_ptr, step - 1, 0);
+    // Wait ack from next_rank to ack the last step data.
+    cuStreamWaitValue32(comm_streams_[nvl_rank_], curr_ack_flag_ptr, tag + step - 1,
+                        CU_STREAM_WAIT_VALUE_EQ);
 
-    // Send the received data to next rank.
-    uint64_t offset = ((nvl_rank_ - step + num_nvl_ranks_) % num_nvl_ranks_) * num_bytes;
-    void *nvl_src_slot_ptr = static_cast<char*>(buffer_ptrs_[nvl_rank_]) + offset;
-    void *nvl_dst_slot_ptr = static_cast<char*>(buffer_ptrs_[next_rank]) + offset;
+    // comm_streams_[nvl_rank_] tells comm_streams_[prev_rank] to start local copy.
+    cuStreamWriteValue32(comm_streams_[nvl_rank_], local_copy_start_ptr, tag + step, 0);
+    cuStreamWaitValue32(comm_streams_[prev_rank], local_copy_start_ptr, tag + step,
+                        CU_STREAM_WAIT_VALUE_EQ);
+
+    // Send this step data to next_rank through NVLink.
+    nvl_src_slot_ptr = curr_data_base_ptr + ping * num_bytes;
+    nvl_dst_slot_ptr = next_data_base_ptr + pong * num_bytes;
     CUDA_CHECK(cudaMemcpyAsync(nvl_dst_slot_ptr, nvl_src_slot_ptr,
                                num_bytes, cudaMemcpyDeviceToDevice,
                                comm_streams_[nvl_rank_]));
 
-    // Copy the received data to output tensor, overlapped with NVLink transfer.
-    void *output_dst_slot_ptr = static_cast<char*>(output_ptr) + offset;
+    // Copy received data into output slot, overlapped with NVLink transfer.
+    offset = ((nvl_rank_ - step + num_nvl_ranks_) % num_nvl_ranks_) * num_bytes;
+    output_dst_slot_ptr = output_ptr + offset;
     CUDA_CHECK(cudaMemcpyAsync(output_dst_slot_ptr, nvl_src_slot_ptr,
                                num_bytes, cudaMemcpyDeviceToDevice,
                                comm_streams_[prev_rank]));
-      
-    // Write ack to prev rank.
-    cuStreamWriteValue32(comm_streams_[nvl_rank_], prev_ack_flag_ptr, step, 0);
 
-    // Wait ack from next rank.
-    cuStreamWaitValue32(comm_streams_[nvl_rank_], curr_ack_flag_ptr, step, 0);
+    // Write signal to next_rank to notify data has been sent.
+    cuStreamWriteValue32(comm_streams_[nvl_rank_], next_sig_flag_ptr, tag + step, 0);
+
+    // Wait for signal from prev_rank to notify data has been sent.
+    cuStreamWaitValue32(comm_streams_[nvl_rank_], curr_sig_flag_ptr, tag + step,
+                        CU_STREAM_WAIT_VALUE_EQ);
+
+    // comm_streams_[nvl_rank_] tells comm_streams_[prev_rank] to start local copy.
+    cuStreamWriteValue32(comm_streams_[prev_rank], local_copy_end_ptr, tag + step, 0);
+    cuStreamWaitValue32(comm_streams_[nvl_rank_], local_copy_end_ptr, tag + step,
+                        CU_STREAM_WAIT_VALUE_EQ);
+
+    ping = 1 - ping;
+    pong = 1 - pong;
   }
+
+  // Copy last step received data from NVLink buffer into output tensor.
+  nvl_src_slot_ptr = curr_data_base_ptr + ping * num_bytes;
+  output_dst_slot_ptr = output_ptr + next_rank * num_bytes;
+  CUDA_CHECK(cudaMemcpyAsync(output_dst_slot_ptr, nvl_src_slot_ptr,
+                             num_bytes, cudaMemcpyDeviceToDevice,
+                             comm_streams_[nvl_rank_]));
+  
+  // Avoid using the same sync value among different calls.
+  // Use a prime number to enlarge the cycle as much as possible.
+  tag += PRIME_TAG_STRIDE;
 
   if (!async_op) {
     cudaStreamSynchronize(comm_streams_[prev_rank]);

--- a/csrc/intranode.cu
+++ b/csrc/intranode.cu
@@ -66,7 +66,7 @@ void Buffer::intranode_all_gather(torch::Tensor& output_tensor,
   void *output_dst_slot_ptr = output_ptr + nvl_rank_ * num_bytes;
   void *nvl_src_slot_ptr = NULL, *nvl_dst_slot_ptr = NULL;
 
-  // Send input to NVLink buffer.
+  // Copy input to NVLink buffer.
   nvl_src_slot_ptr = curr_data_base_ptr + ping * num_bytes;
   CUDA_CHECK(cudaMemcpyAsync(nvl_src_slot_ptr, tensor.data_ptr(), 
                              num_bytes, cudaMemcpyDeviceToDevice, 
@@ -107,7 +107,7 @@ void Buffer::intranode_all_gather(torch::Tensor& output_tensor,
     cuStreamWaitValue32(comm_streams_[nvl_rank_], curr_sig_flag_ptr, tag + step,
                         CU_STREAM_WAIT_VALUE_EQ);
 
-    // comm_streams_[nvl_rank_] tells comm_streams_[prev_rank] to start local copy.
+    // comm_streams_[prev_rank] tells comm_streams_[nvl_rank_] local copy ends.
     cuStreamWriteValue32(comm_streams_[prev_rank], local_copy_end_ptr, tag + step, 0);
     cuStreamWaitValue32(comm_streams_[nvl_rank_], local_copy_end_ptr, tag + step,
                         CU_STREAM_WAIT_VALUE_EQ);

--- a/csrc/utils.hpp
+++ b/csrc/utils.hpp
@@ -5,6 +5,9 @@
 
 #include <cuda/pipeline>
 
+#define PRIME_TAG_START   13
+#define PRIME_TAG_STRIDE  971
+
 #define HOST_DEVICE __forceinline__ __host__ __device__
 #define DEVICE __forceinline__ __device__
 #define HOST __forceinline__ __host__

--- a/nvshmem_tutorial/buffer.py
+++ b/nvshmem_tutorial/buffer.py
@@ -1,3 +1,4 @@
+from multiprocessing import Value
 import os
 import torch
 import torch.distributed as dist
@@ -130,7 +131,17 @@ class NvshmemBuffer:
         if self.num_rdma_ranks > 1:
             self.runtime.internode_all_gather(tensor_list, tensor, async_op)
         else:
-            self.runtime.intranode_all_gather(tensor_list, tensor, async_op)
+            # self.runtime.intranode_all_gather(tensor_list, tensor, async_op)
+            raise ValueError("Only support internode all-gather for now")
+
+    def all_gather_into_tensor(self, output_tensor, tensor, async_op=False):
+        if not tensor.is_cuda:
+            raise ValueError("Tensor must be CUDA tensor")
+        if len(tensor_list) != self.group_size:
+            raise ValueError("Tensor list must match group size")
+        if self.num_rdma_ranks > 1:
+            raise ValueError("Only support intranode all-gather for now")
+        self.runtime.intranode_all_gather(output_tensor, tensor, async_op)
 
     def is_same_rdma_rank(self, rank):
         """Check if the rank is the same RDMA rank."""

--- a/nvshmem_tutorial/buffer.py
+++ b/nvshmem_tutorial/buffer.py
@@ -137,8 +137,8 @@ class NvshmemBuffer:
     def all_gather_into_tensor(self, output_tensor, tensor, async_op=False):
         if not tensor.is_cuda:
             raise ValueError("Tensor must be CUDA tensor")
-        if len(tensor_list) != self.group_size:
-            raise ValueError("Tensor list must match group size")
+        if output_tensor.shape[0] != self.group_size:
+            raise ValueError("output tensor must match group size")
         if self.num_rdma_ranks > 1:
             raise ValueError("Only support intranode all-gather for now")
         self.runtime.intranode_all_gather(output_tensor, tensor, async_op)


### PR DESCRIPTION
Support ring algorithm for intranode `all-gather`. 

The performance is a little better than mesh `all-gather` when data size is large. Due to the overhead of ops launch such as `cudaMemcpyAsync` and `cuStreamWaitValue32`, the overall performance is still poorer than `NCCL`, especially when data size is small.

The **peak** performance comparison between ring-based and mesh-based `all-gather` is as below:
- Ring-based 👉 **232GBps**
- Mesh-based 👉 **210GBps**

It's an approximately **1.1x** performance gain.

When the data size per rank is smaller than **64MB**, the ring-based approach yields poorer performance than mesh-based one. I believe this is due to the overhead of **CUDA HOST API**. I will implement this ring-based `all-gather` in CUDA kernel utilizing `TMA` in the nearest future, which will be impressive, even yielding performance much closer to `NCCL`. Also I will support **fixed-size buffer feature** in the next implementation of ring-based `all-gather`.

It also shows that the larger the data size is, the better the performance is for ring-based `all-gather`, which is anticipated because the overhead can be amortized when data size is large.

The most useful advantage against mesh-based `all-gather` is that the size of communication buffer can be fixed. In addition, only 2 `CUDAStream`s are necessary while mesh-based `all-gather` occupies 8 `CUDAStream`s in total. This also suggests that **ring-based approach is much more scalable.**

It is also worth noting that ring-based implementation involves a **`Double Buffer`** technique, which can enable us to reuse the communication buffer instead of having a separate buffer for the data from each rank. This technique is the **backbone of optimal buffer usage**.

The following is the benchmarks for ring-based `all-gather`:
```
===============================================================================================
 All-Gather Benchmark (world_size=8, dtype=torch.bfloat16)
 Warmup Iterations: 10, Benchmark Iterations: 50
===============================================================================================
   Size (KB) |     NCCL Time (ms) |  NVSHMEM Time (ms) |     NCCL BW (GB/s) |  NVSHMEM BW (GB/s)
------------------------------------------------------------------------------------------------
          32 |             0.0281 |             0.1566 |               1.02 |               0.18
         128 |             0.0462 |             0.1557 |               2.48 |               0.74
         512 |             0.0331 |             0.1551 |              13.87 |               2.96
        2048 |             0.0320 |             0.1566 |              57.33 |              11.71
        8192 |             0.0580 |             0.1767 |             126.60 |              41.55
       16384 |             0.0739 |             0.2000 |             198.55 |              73.40
       32768 |             0.1255 |             0.2479 |             234.00 |             118.41
       65536 |             0.2094 |             0.3410 |             280.46 |             172.19
      131072 |             0.3808 |             0.6231 |             308.44 |             188.47
      262144 |             0.7154 |             1.1505 |             328.32 |             204.16
      524288 |             1.3944 |             2.1673 |             336.90 |             216.75
     1048576 |             2.7232 |             4.1619 |             345.00 |             225.75
     2097152 |             5.3354 |             8.1561 |             352.18 |             230.39
     4194304 |            10.5433 |            16.1415 |             356.45 |             232.82
     8388608 |            20.8931 |            32.4662 |             359.75 |             231.51
```

The following is the benchmark of mesh-based `all-gather`(***forget about the NCCL performance :(*** ):
```
===============================================================================================
 All-Gather Benchmark (world_size=8, dtype=torch.bfloat16)
 Warmup Iterations: 10, Benchmark Iterations: 50
===============================================================================================
   Size (KB) |     NCCL Time (ms) |  NVSHMEM Time (ms) |     NCCL BW (GB/s) |  NVSHMEM BW (GB/s)
------------------------------------------------------------------------------------------------
           4 |             0.1383 |             0.0400 |               0.21 |               0.72
          16 |             0.1173 |             0.0403 |               0.98 |               2.85
          64 |             0.1231 |             0.0404 |               3.73 |              11.35
         256 |             0.1227 |             0.0403 |              14.96 |              45.50
        1024 |             0.1192 |             0.0517 |              61.59 |             141.92
        2048 |             0.1323 |             0.0844 |             110.93 |             174.00
        4096 |             0.1857 |             0.1637 |             158.15 |             179.39
        8192 |             0.2972 |             0.3110 |             197.58 |             188.83
       16384 |             0.5243 |             0.6193 |             224.01 |             189.63
       32768 |             0.9678 |             1.1903 |             242.70 |             197.33
       65536 |             1.8294 |             2.4843 |             256.79 |             189.09
      131072 |             3.5637 |             4.7416 |             263.64 |             198.15
      262144 |             6.9938 |             9.4852 |             268.67 |             198.10
      524288 |            13.8480 |            18.4222 |             271.38 |             204.00
     1048576 |            27.4208 |            36.1864 |             274.11 |             207.71
```